### PR TITLE
fix: ObxValue extends wrong type

### DIFF
--- a/lib/get_state_manager/src/rx_flutter/rx_obx_widget.dart
+++ b/lib/get_state_manager/src/rx_flutter/rx_obx_widget.dart
@@ -52,7 +52,7 @@ class Obx extends ObxWidget {
 /// false.obs,
 /// ),
 /// ```
-class ObxValue<T extends RxInterface<T>> extends ObxWidget {
+class ObxValue<T extends RxInterface> extends ObxWidget {
   /// Constructs an [ObxValue] widget with the given [builder] and [data].
   const ObxValue(this.builder, this.data, {super.key});
 


### PR DESCRIPTION
This is for fixing [this issue](https://github.com/Aniketkhote/refreshed/issues/33). Removing `<T>` on `ObxValue<T extends RxInterface<T>>` on the `RxInterface`.

## Pre-launch Checklist

- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or @Aniketkhote said the PR is test-exempt.
- [ ] All existing and new tests are passing.
